### PR TITLE
Github Actions: Add caching of node_modules and selective eslint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,16 @@ jobs:
     - name: What files where changed?
       run: |
         echo ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
-        
-    - run: npm run full-test-ci
+
+    - name: Run selective lint & full test (if pull request)
+      run: npm run full-test-ci
+      if: ${{ github.event_name == 'pull_request' }}
       env:
         CI: true
         FILES: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
+
+    - name: Run full lint & test (if pushing to master)
+      run: npm run full-test
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      env:
+        CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+
 
 jobs:
   build:
@@ -16,15 +18,39 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v2
+    
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: Zarel/setup-node@patch-1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm run full-test
+        cache: 'npm'
+        
+    - name: Cache node_modules or restore if already cached
+      uses: actions/cache@v3
+      with:
+        path: 'node_modules'
+        key: ${{ runner.os }}-node-${{ matrix.node-version }}-modules-${{ hashFiles('package-lock.json') }}
+          
+    - run: npm install && npm list
+    
+    - name: Get all changed *.js, *.ts & *.tsx file(s)
+      id: changed-files
+      uses: tj-actions/changed-files@v35
+      with:
+        files: |
+          **/*.js
+          **/*.ts
+          **/*.tsx
+
+    - name: What files where changed?
+      run: |
+        echo ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
+        
+    - run: npm run full-test-ci
       env:
         CI: true
+        FILES: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -577,7 +577,7 @@ export const Formats: FormatList = [
 		mod: 'pokebilities',
 		// searchShow: false,
 		ruleset: ['Standard OMs', 'Sleep Clause Mod', 'Min Source Gen = 9'],
-		banlist: ['Chi-Yu', 'Flutter Mane', 'Houndstone', 'Iron Bundle', 'Koraidon', 'Miraidon', 'Palafin', 'Arena Trap', 'Moody', 'Shadow Tag', 'King\'s Rock', 'Baton Pass'],
+		banlist: ['Chi-Yu', 'Espathra', 'Flutter Mane', 'Houndstone', 'Iron Bundle', 'Koraidon', 'Miraidon', 'Palafin', 'Arena Trap', 'Moody', 'Shadow Tag', 'King\'s Rock', 'Baton Pass'],
 		onValidateSet(set) {
 			const species = this.dex.species.get(set.species);
 			const unSeenAbilities = Object.keys(species.abilities)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test": "mocha",
     "posttest": "npm run tsc",
     "full-test": "npm run lint && npm run tsc && mocha --timeout 8000 --forbid-only -g \".*\"",
+    "full-test-ci": "eslint ${FILES} --max-warnings 0 && npm run tsc && mocha --timeout 8000 --forbid-only -g \".*\"",
     "postinstall": "npm run build"
   },
   "bin": "./pokemon-showdown",


### PR DESCRIPTION
A few potential optimizations to the Github Actions job:

1. Use [actions/cache@v3](https://github.com/actions/cache) to create a Github-hosted, immutable cache entry that stores a specified directory (in this case, `node_modules`). A new entry is created whenever `package-lock.json` is updated or a new node version is used in the Github Action. Old entries are auto-evicted from the cache after a few days of inactivity or due to lack of space. Similar to what is done [here](https://github.com/prettier/eslint-config-prettier/blob/main/.github/workflows/check.yml), saves about a minute in the `npm install` step
2. Use [tj-actions/changed-files@v35](https://github.com/tj-actions/changed-files) to fetch all changed/modified js, ts & tsx files in a PR, and use eslint only on those. If there's a push to master (force push or PR merge), a full lint is run instead. Saves a couple of minutes for focused PRs

The remaining large chunk of the time is in `mocha` (~6-8m), and a smaller chunk is from `tsc`